### PR TITLE
Use updated Tor DNS exit list

### DIFF
--- a/main.test.js
+++ b/main.test.js
@@ -1,11 +1,8 @@
 const IsTorExit = require(require("path").join(__dirname, "main.js"));
 
-const defaultDestinationIp = "216.58.206.110"; // google.com
-const defaultDestinationPort = 443; // https
-
 describe("Not exit nodes", () => {
   test("google", async done => {
-    const result = await IsTorExit(defaultDestinationIp);
+    const result = await IsTorExit("216.58.206.110");
     expect(result).toBe(false);
     done();
   });


### PR DESCRIPTION
The DNS exit list has has been [simplified and moved](https://lists.torproject.org/pipermail/tor-project/2020-March/002759.html):

> The old DNS exit list would have lookups that look like:
> 
>     <reverse client ip>.<server port>.<reverse server ip>.ip-port.exitlist.torproject.org
> 
> For services that are accessed via multiple IP addresses, e.g. IRC networks with multiple servers or websites behind load balancers, this leads to service operators needing to perform multiple lookups in order to have confidence that an IP address is not an exit relay. Instead, services can now use this simplified service:
> 
>     <reverse client ip>.dnsel.torproject.org
> 
> […]
> 
> **The old DNS exit list service will be turned off on the 1st April 2020. Please ensure you have updated to the new service before this time.**

This means for IsTorExit:

- Remove the destination IP and port options.
- Change the DNS endpoint.